### PR TITLE
Add Trip Tracking & Reset to TTIPLP IOC

### DIFF
--- a/ttiplpSup/ttiplp.db
+++ b/ttiplpSup/ttiplp.db
@@ -293,6 +293,13 @@ record(mbbiDirect, "$(P)LSR")
     field(INP,  "@ttiplp.proto getEventStatusRegister($(ADDRESS)) $(PORT)")
 }
 
+# Attempt to clear all trip conditions
+record(bo, "$(P)TRIPRST")
+{
+    field(DESC, "Try to clear all set trip bits")
+    field(OUT,  "@ttiplp.proto tripReset $(PORT)")
+    field(DTYP, "stream")
+}
 
 
 #**************************

--- a/ttiplpSup/ttiplp.db
+++ b/ttiplpSup/ttiplp.db
@@ -264,6 +264,29 @@ record(fanout, "$(P)OVERCURR:UPDATE")
     field(LNK2, "$(P)OUTPUT")
 }
 
+# Check the overvolt trip status
+record(bi, "$(P)OVERVOLT:STAT")
+{
+    field(DESC, "Overvolt trip status")
+    field(SCAN, "Passive")
+    field(ZNAM, "Ok")
+    field(ONAM, "Error")
+    field(VAL, "0")
+    field(PINI, "1")
+} 
+
+# Check the overcurrent trip status
+record(bi, "$(P)OVERCURR:STAT")
+{
+    field(DESC, "Overcurrent trip status")
+    field(SCAN, "Passive")
+    field(ZNAM, "Ok")
+    field(ONAM, "Error")
+    field(VAL, "0")
+    field(PINI, "1")
+} 
+
+
 
 #**************************
 #*** Simulation Records ***

--- a/ttiplpSup/ttiplp.db
+++ b/ttiplpSup/ttiplp.db
@@ -292,6 +292,26 @@ record(bi, "$(P)OVERCURR:STAT")
     info(alarm, "TTIPLP")
 } 
 
+# Check the voltage limit status
+record(bi, "$(P)VOLTAGE:STAT")
+{
+    field(DESC, "Output in voltage limit")
+    field(SCAN, "Passive")
+    field(ZNAM, "Ok")
+    field(ONAM, "Limit")
+    field(INP,  "$(P)LSR.B0 CP MSS")
+}
+
+# Check the current limit status
+record(bi, "$(P)CURRENT:STAT")
+{
+    field(DESC, "Output in current limit")
+    field(SCAN, "Passive")
+    field(ZNAM, "Ok")
+    field(ONAM, "Limit")
+    field(INP,  "$(P)LSR.B1 CP MSS")
+}
+
 # Check for a trip that requires a manual reset or reboot of the device.
 record(bi, "$(P)TRIP:STAT")
 {

--- a/ttiplpSup/ttiplp.db
+++ b/ttiplpSup/ttiplp.db
@@ -272,6 +272,10 @@ record(bi, "$(P)OVERVOLT:STAT")
     field(ZNAM, "Ok")
     field(ONAM, "Tripped")
     field(INP,  "$(P)LSR.B2 CP MSS")
+
+    field(ZSV,  "NO_ALARM")
+    field(OSV,  "MAJOR")
+    info(alarm, "TTIPLP")
 } 
 
 # Check the overcurrent trip status
@@ -282,6 +286,10 @@ record(bi, "$(P)OVERCURR:STAT")
     field(ZNAM, "Ok")
     field(ONAM, "Tripped")
     field(INP,  "$(P)LSR.B3 CP MSS")
+
+    field(ZSV,  "NO_ALARM")
+    field(OSV,  "MAJOR")
+    info(alarm, "TTIPLP")
 } 
 
 # Read from the Limit Event Status Register

--- a/ttiplpSup/ttiplp.db
+++ b/ttiplpSup/ttiplp.db
@@ -270,9 +270,8 @@ record(bi, "$(P)OVERVOLT:STAT")
     field(DESC, "Overvolt trip status")
     field(SCAN, "Passive")
     field(ZNAM, "Ok")
-    field(ONAM, "Error")
-    field(VAL, "0")
-    field(PINI, "1")
+    field(ONAM, "Tripped")
+    field(INP,  "$(P)LSR.B2 CP MSS")
 } 
 
 # Check the overcurrent trip status
@@ -281,10 +280,18 @@ record(bi, "$(P)OVERCURR:STAT")
     field(DESC, "Overcurrent trip status")
     field(SCAN, "Passive")
     field(ZNAM, "Ok")
-    field(ONAM, "Error")
-    field(VAL, "0")
-    field(PINI, "1")
+    field(ONAM, "Tripped")
+    field(INP,  "$(P)LSR.B3 CP MSS")
 } 
+
+# Read from the Limit Event Status Register
+record(mbbiDirect, "$(P)LSR")
+{
+    field(DESC, "Limit Event Status Register")
+    field(SCAN, "1 second")
+    field(DTYP, "stream")
+    field(INP,  "@ttiplp.proto getEventStatusRegister($(ADDRESS)) $(PORT)")
+}
 
 
 

--- a/ttiplpSup/ttiplp.db
+++ b/ttiplpSup/ttiplp.db
@@ -135,6 +135,7 @@ record(ai, "$(P)OVERVOLT:SP:RBV")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:OVERVOLT:SP:RBV")
     field(SDIS, "$(P)DISABLE")
+    info(archive, "VAL")
     info(INTEREST, "MEDIUM")
 }
 # The read back over current protection trip
@@ -150,6 +151,7 @@ record(ai, "$(P)OVERCURR:SP:RBV")
     field(SIML, "$(P)SIM")
     field(SIOL, "$(P)SIM:OVERCURR:SP:RBV")
     field(SDIS, "$(P)DISABLE")
+    info(archive, "VAL")
     info(INTEREST, "MEDIUM")
 }
 # The Readback of the output state

--- a/ttiplpSup/ttiplp.db
+++ b/ttiplpSup/ttiplp.db
@@ -292,6 +292,20 @@ record(bi, "$(P)OVERCURR:STAT")
     info(alarm, "TTIPLP")
 } 
 
+# Check for a trip that requires a manual reset or reboot of the device.
+record(bi, "$(P)TRIP:STAT")
+{
+    field(DESC, "Trip status needing physical reset")
+    field(SCAN, "Passive")
+    field(ZNAM, "Ok")
+    field(ONAM, "Tripped")
+    field(INP,  "$(P)LSR.B6 CP MSS")
+
+    field(ZSV,  "NO_ALARM")
+    field(OSV,  "MAJOR")
+    info(alarm, "TTIPLP")
+}
+
 # Read from the Limit Event Status Register
 record(mbbiDirect, "$(P)LSR")
 {

--- a/ttiplpSup/ttiplp.proto
+++ b/ttiplpSup/ttiplp.proto
@@ -26,13 +26,13 @@ setCurrent {out "I\$1 %f";
 }
 
 # Over voltage protection trip
-getOverVoltageProtectTrip {out "OVP\$1?";in "%f"}
+getOverVoltageProtectTrip {out "OVP\$1?";in "VP\$1 %f"}
 setOverVoltageProtectTrip {out "OVP\$1 %f";
 @init { getOverVoltageProtectTrip; }
 }
 
 # Over current protection trip
-getOverCurrentProtectTrip {out "OCP\$1?";in "%f"}
+getOverCurrentProtectTrip {out "OCP\$1?";in "CP\$1 %f"}
 setOverCurrentProtectTrip {out "OCP\$1 %f";
 @init { getOverCurrentProtectTrip; }
 }

--- a/ttiplpSup/ttiplp.proto
+++ b/ttiplpSup/ttiplp.proto
@@ -39,3 +39,6 @@ setOverCurrentProtectTrip {out "OCP\$1 %f";
 
 # Get the limit event status register
 getEventStatusRegister {out "LSR\$1?";in "%d"}
+
+# Attempt to clear all trip conditions
+tripReset {out "TRIPRST"}

--- a/ttiplpSup/ttiplp.proto
+++ b/ttiplpSup/ttiplp.proto
@@ -36,3 +36,6 @@ getOverCurrentProtectTrip {out "OCP\$1?";in "%f"}
 setOverCurrentProtectTrip {out "OCP\$1 %f";
 @init { getOverCurrentProtectTrip; }
 }
+
+# Get the limit event status register
+getEventStatusRegister {out "LSR\$1?";in "%d"}


### PR DESCRIPTION
Add trip functionality to the IOC. Reads from the Limit Event Status Register (LSR) on the device then updates the `OVERCURR:STAT` and `OVERVOLT:STAT` records, which will alarm when in their `HIGH` state. 

Also adds a `TRIPRST` record which will clear the LSR and allow the device to begin outputting again. The device will not output when either of the trip bits have been set (i.e: either of the OVERCURR:STAT or OVERVOLT:STAT records are in their HIGH state)

Part of this work also fixes a bug with the trip sp readback not displaying. 

Partially Resolves ISISComputingGroup/IBEX#7213